### PR TITLE
Robust path handling and universal placeholder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Select lines using visual selection (<kbd>V</kbd>) or using text objects (<kbd>v
 
 This extracts the selected lines from the current file into a new file (e.g. `newfilename.js`) in the same directory. If the new file doesn't have an extension, it will automatically be the same as the original.
 
+If the destination directory doesn't exist, it will automatically be created.
+
 ## Copying headers
 
 You can copy the file's headers and automatically add an import statement to the original file (eg, `import X from './X'`):

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This extracts from the current file into a new file `newfilename.js` in the same
 
 ## Copying headers
 
-You can copy the file's headers and leave an import statement behind (eg, `import X from './X'`).
+You can copy the file's headers and automatically add an import statement to the original file (eg, `import X from './X'`):
 
 ```
 :'<,'>Xtract FILENAME N
@@ -87,12 +87,12 @@ This copies lines 1-3 into a new buffer (the header) and 8-10 right after it (th
 + }
 ```
 
-## Updating placeholders
+## Updating import strings
 
-Edit `g:xtract_placeholders` to update the string it leaves behind:
+Edit the `g:xtract_importstrings` dictionary to change the import statement that is added to the header in the original file:
 
 ```js
-let g:xtract_placeholders = {
+let g:xtract_importstrings = {
 \ "javascript": "import %s from './%s'",
 \ "jsx": "import %s from './%s'",
 \ "scss": "@import './%s';",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Select lines using visual selection (<kbd>V</kbd>) or using text objects (<kbd>v
 :Xtract newfilename⏎
 ```
 
-This extracts the selected lines from the current file into a new file (e.g. `newfilename.js`) in the same directory. The extension of the new file will be the same as the original.
+This extracts the selected lines from the current file into a new file (e.g. `newfilename.js`) in the same directory. If the new file doesn't have an extension, it will automatically be the same as the original.
 
 ## Copying headers
 
@@ -33,7 +33,7 @@ You can copy the file's headers and automatically add an import statement to the
 ```
 
 - `'<,'>` — the range of the body
-- `FILENAME` — the new file (no extension)
+- `FILENAME` — the new file (extension may be omitted)
 - `HEADERSIZE` — number of lines in the header (optional)
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This extracts from the current file into a new file `newfilename.js` in the same
 
 ## Copying headers
 
-You can copy the files headers and leave an import statement behind (eg, `import X from './X'`).
+You can copy the file's headers and leave an import statement behind (eg, `import X from './X'`).
 
 ```
 :'<,'>Xtract FILENAME N

--- a/README.md
+++ b/README.md
@@ -16,25 +16,25 @@ Plug 'rstacruz/vim-xtract'
 
 ## Usage
 
-Select a few lines. You can use a visual selection (<kbd>V</kbd>) or using text objects (<kbd>v</kbd><kbd>ap</kbd><kbd>ap</kbd>...). Then press:
+Select lines using visual selection (<kbd>V</kbd>) or using text objects (<kbd>v</kbd><kbd>ap</kbd><kbd>ap</kbd>...). Then type:
 
 ```
 :Xtract newfilename⏎
 ```
 
-This extracts from the current file into a new file `newfilename.js` in the same directory, keeping the extension of the current file.
+This extracts the selected lines from the current file into a new file (e.g. `newfilename.js`) in the same directory. The extension of the new file will be the same as the original.
 
 ## Copying headers
 
 You can copy the file's headers and automatically add an import statement to the original file (eg, `import X from './X'`):
 
 ```
-:'<,'>Xtract FILENAME N
+:'<,'>Xtract FILENAME HEADERSIZE
 ```
 
 - `'<,'>` — the range of the body
 - `FILENAME` — the new file (no extension)
-- `N` — number of lines in the header (optional)
+- `HEADERSIZE` — number of lines in the header (optional)
 
 #### Example
 
@@ -54,13 +54,13 @@ Let's say you have a file like this `index.js` below. We want to extract the hea
 10   }
 ```
 
-Select the body first (lines `8` to `10`) using <kbd>V</kbd>, then type:
+Select lines (e.g. lines `8` to `10`) using visual mode (<kbd>V</kbd>), then type:
 
 ```
 :Xtract MyComponent 3⏎
 ```
 
-This copies lines 1-3 into a new buffer (the header) and 8-10 right after it (the block). The resulting files will look like these:
+This copies the header (lines 1-3) and pastes the selected block right after it into a new file buffer. The import statement referencing the new file will be inserted right before the last line of the header in the original file. The resulting files will look like these:
 
 ```diff
  [index.js]
@@ -71,10 +71,11 @@ This copies lines 1-3 into a new buffer (the header) and 8-10 right after it (th
   export function App () {
     return <MyComponent />
   }
--
+
 - export function MyComponent () {
 -   return <div></div>
 - }
++ /* ./MyComponent.js */
 ```
 
 ```diff
@@ -89,7 +90,7 @@ This copies lines 1-3 into a new buffer (the header) and 8-10 right after it (th
 
 ## Updating import strings
 
-Edit the `g:xtract_importstrings` dictionary to change the import statement that is added to the header in the original file:
+Define your own `g:xtract_importstrings` dictionary to change the import statement that is added to the header in the original file:
 
 ```js
 let g:xtract_importstrings = {

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -93,6 +93,11 @@ function! s:Xtract(bang, target, ...) range abort
 
   " Put the cursor at the top of the new buffer
   silent 1
+
+  " Output message
+  let numlines = a:lastline - a:firstline + 1
+  redraw
+  echomsg numlines.' line'.(numlines == 1 ? '' : 's').' extracted to file: '.target
 endfunction
 
 " Open buffer in a split window or focus it if it's already open

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -3,8 +3,8 @@ if exists('g:loaded_xtract') || &cp || v:version < 700
 endif
 let g:loaded_xtract = 1
 
-" Placeholders
-let g:xtract_placeholders = {
+" Import strings
+let g:xtract_importstrings = {
 \ "javascript": "import %s from './%s'",
 \ "jsx": "import %s from './%s'",
 \ "scss": "@import './%s';",
@@ -58,7 +58,7 @@ function! s:Xtract(bang, target, ...) range abort
   " Insert import statement right after the header (if header was specified
   " and we have an appropriate import template)
   if header
-    let import = s:get_placeholder()
+    let import = s:get_importstring()
 
     if import != -1
       let import = substitute(import, "%s", a:target, "g")
@@ -110,8 +110,8 @@ function! s:get_indent(line)
   return matchstr(getline(a:line), "^ *")
 endfunction
 
-function! s:get_placeholder()
-  return get(g:xtract_placeholders, &filetype, -1)
+function! s:get_importstring()
+  return get(g:xtract_importstrings, &filetype, -1)
 endfunction
 
 "

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -25,7 +25,7 @@ function! s:Xtract(bang, target, ...) range abort
   let header = get(a:, '1')
   let target = a:target
   let extension = expand("%:e")
-  let indent = s:get_indent(a:firstline)
+  let indent = s:get_indent_at(a:firstline)
 
   " If current file has an extension and the target doesn't already have it, append it
   if !empty(extension) && !s:path_has_extension(target, extension)
@@ -64,7 +64,7 @@ function! s:Xtract(bang, target, ...) range abort
       let import = substitute(import, "%s", a:target, "g")
 
       " Capture the indent present on the next-to-last line of the header
-      let header_indent = s:get_indent(header - 1)
+      let header_indent = s:get_indent_at(header - 1)
 
       " Append the import statement to the header
       silent exe "norm! :".header."insert\<CR>".header_indent.import."\<CR>.\<CR>"
@@ -78,7 +78,7 @@ function! s:Xtract(bang, target, ...) range abort
   let placeholder = s:comment(&commentstring, target)
 
   " Insert the placeholder where the text was removed
-  silent exe "norm! :".origline."insert\<CR>".indent.placeholder."\<CR>.\<CR>"
+  silent exe "norm! :".origline."insert\<CR>\<C-u>".indent.placeholder."\<CR>.\<CR>"
 
   " Open a new window and paste the extracted block in
   silent exe "split ".target
@@ -105,8 +105,8 @@ function! s:path_has_extension(path, ext)
   return strcharpart(a:path, strchars(a:path) - (strchars(a:ext) + 1), strchars(a:ext) + 1) == ".".a:ext
 endfunction
 
-function! s:get_indent(line)
-  return matchstr(getline(a:line), "^ *")
+function! s:get_indent_at(line)
+  return matchstr(getline(a:line), "^[ \t]*")
 endfunction
 
 function! s:get_importstring()

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -22,10 +22,14 @@ function! s:Xtract(bang, target, ...) range abort
   let last = a:lastline
   let head = get(a:, '1')
   let range = first.",".last
+  let ext = expand("%:e")
+  let fname = a:target
 
-  let ext = expand("%:e")        " js
+  if !empty(ext)
+    let fname .= '.'.ext
+  endif
+
   let path = expand("%:h")       " /path/to
-  let fname = a:target.".".ext   " target.js
   let fullpath = path."/".fname  " /path/to/target.js
 
   " Raise an error if invoked without a bang

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -80,12 +80,9 @@ function! s:Xtract(bang, target, ...) range abort
   " Insert the placeholder where the text was removed
   silent exe "norm! :".origline."insert\<CR>\<C-u>".indent.placeholder."\<CR>.\<CR>"
 
-  " Open a new window and paste the extracted block in
-  silent exe "split ".target
-  silent put
-
-  " Delete the empty line at the top of the file (without taking a register)
-  silent 1delete _
+  " Open target buffer and paste the extracted block at the end
+  call s:open_buffer(target)
+  call s:paste_append()
 
   " Insert the header (if specified) at the top
   if header
@@ -99,6 +96,34 @@ function! s:Xtract(bang, target, ...) range abort
 
   " Put the cursor at the top of the new buffer
   silent 1
+endfunction
+
+" Open buffer in a split window or focus it if it's already open
+function! s:open_buffer(name)
+  let bufinfo = getbufinfo(a:name)
+
+  if len(bufinfo) > 0
+    let bufinfo = bufinfo[0]
+
+    if len(bufinfo.windows) > 0
+      call win_gotoid(bufinfo.windows[0])
+      return
+    endif
+  endif
+
+  silent exe "split ".a:name
+endfunction
+
+function! s:paste_append()
+  let bufwasempty = line('$') == 1 && getline(1) == ''
+
+  " Paste at the end of the buffer
+  silent $put
+
+  " If the buffer was empty, delete the residual empty line at the top of the buffer (without taking a register)
+  if bufwasempty
+    silent 1delete _
+  endif
 endfunction
 
 function! s:path_has_extension(path, ext)

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -32,8 +32,8 @@ function! s:Xtract(bang, target, ...) range abort
     let target .= '.'.extension
   endif
 
-  " Build the full target path
-  if target[0] == '~' && target[1] == '/'
+  " Expand the full target path
+  if target[:1] == '~/'
     let target = expand(target)
   elseif target[0] != '/'
     let target = expand("%:h").'/'.target
@@ -49,7 +49,7 @@ function! s:Xtract(bang, target, ...) range abort
     silent exe "1,".header."yank x"
   endif
 
-  " Remove block (default register)
+  " Remove block (use default register)
   silent exe a:firstline.",".a:lastline."del"
 
   " Keep track of the original line where the content was extracted from
@@ -78,17 +78,16 @@ function! s:Xtract(bang, target, ...) range abort
   let placeholder = s:comment(&commentstring, target)
 
   " Insert the placeholder where the text was removed
-  silent exe "norm! :".(origline)."insert\<CR>".indent.placeholder."\<CR>.\<CR>"
+  silent exe "norm! :".origline."insert\<CR>".indent.placeholder."\<CR>.\<CR>"
 
-  " Open a new window and paste the block in
-  silent execute "split ".target
+  " Open a new window and paste the extracted block in
+  silent exe "split ".target
   silent put
 
-  " Delete the empty line at the top of the file (without changing a register)
-  silent 1
-  silent normal '"_dd'
+  " Delete the empty line at the top of the file (without taking a register)
+  silent 1delete _
 
-  " Paste the header in (if specified)
+  " Insert the header (if specified) at the top
   if header
     silent put! x
   endif

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -124,7 +124,7 @@ function! s:add_default_extension(path, ext)
 endfunction
 
 function! s:get_indent_at(line)
-  return matchstr(getline(a:line), "^[ \t]*")
+  return matchstr(getline(a:line), '^\s*')
 endfunction
 
 function! s:get_importstring()

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -18,10 +18,7 @@ let g:xtract_placeholders = {
 command -range -bang -nargs=* Xtract :<line1>,<line2>call s:Xtract(<bang>0,<f-args>)
 
 function! s:Xtract(bang, target, ...) range abort
-  let first = a:firstline
-  let last = a:lastline
   let head = get(a:, '1')
-  let range = first.",".last
   let target = a:target
   let extension = expand("%:e")
 
@@ -44,11 +41,11 @@ function! s:Xtract(bang, target, ...) range abort
 
   " Copy header (register 'x')
   if head
-    silent exe "1," . head . "yank x"
+    silent exe "1,".head."yank x"
   endif
 
-  " Remove block (register default)
-  silent exe range."del"
+  " Remove block (default register)
+  silent exe a:firstline.",".a:lastline."del"
 
   " Remove extra lines at the end of the file (not working?)
   silent! '%s#\($\n\s*\)\+\%$##'
@@ -61,11 +58,11 @@ function! s:Xtract(bang, target, ...) range abort
     " Go to where the head is and insert the placeholder
     silent exe "norm! :".head."insert\<CR>".spaces.placeholder."\<CR>.\<CR>"
   else
-    let spaces = matchstr(getline(first),"^ *")
+    let spaces = matchstr(getline(a:firstline),"^ *")
     let placeholder = substitute(&commentstring, "%s", " ".target, "")
 
     " Insert the placeholder where the text was extracted
-    silent exe "norm! :".first."insert\<CR>".spaces.placeholder."\<CR>.\<CR>"
+    silent exe "norm! :".a:firstline."insert\<CR>".spaces.placeholder."\<CR>.\<CR>"
   endif
 
   " Open a new window and paste the block in

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -23,14 +23,7 @@ command -range -bang -nargs=* Xtract :<line1>,<line2>call s:Xtract(<bang>0,<f-ar
 
 function! s:Xtract(bang, target, ...) range abort
   let headersize = get(a:, '1')
-  let target = a:target
-  let extension = expand("%:e")
-  let indent = s:get_indent_at(a:firstline)
-
-  " If current file has an extension and the target doesn't already have it, append it
-  if !empty(extension) && !s:path_has_extension(target, extension)
-    let target .= '.'.extension
-  endif
+  let target = s:add_default_extension(a:target, expand('%:e'))
 
   " Expand the full target path
   if target[:1] == '~/'
@@ -48,6 +41,9 @@ function! s:Xtract(bang, target, ...) range abort
   if headersize
     silent exe "1,".headersize."yank x"
   endif
+
+  " Capture the indent of the first selected line before the selected lines are removed
+  let indent = s:get_indent_at(a:firstline)
 
   " Remove block (use default register)
   silent exe a:firstline.",".a:lastline."del"
@@ -89,7 +85,7 @@ function! s:Xtract(bang, target, ...) range abort
     silent put! x
   endif
 
-  " Ensure the target directory exists
+  " Create the target directory if it doesn't already exist
   if !isdirectory(fnamemodify(target, ':h'))
     call mkdir(fnamemodify(target, ':h'), 'p')
   endif
@@ -126,8 +122,8 @@ function! s:paste_append()
   endif
 endfunction
 
-function! s:path_has_extension(path, ext)
-  return strcharpart(a:path, strchars(a:path) - (strchars(a:ext) + 1), strchars(a:ext) + 1) == ".".a:ext
+function! s:add_default_extension(path, ext)
+  return a:ext != '' && fnamemodify(a:path, ':e') == '' ? a:path.'.'.a:ext : a:path
 endfunction
 
 function! s:get_indent_at(line)

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -53,14 +53,19 @@ function! s:Xtract(bang, target, ...) range abort
   " Remove extra lines at the end of the file (not working?)
   silent! '%s#\($\n\s*\)\+\%$##'
 
-  " Replace it
-  let placeholder = substitute(s:get_placeholder(), "%s", a:target, "g")
-
+  " Insert the placeholder
   if head
     let spaces = matchstr(getline(head - 1),"^ *")
+    let placeholder = substitute(s:get_placeholder(), "%s", a:target, "g")
 
     " Go to where the head is and insert the placeholder
     silent exe "norm! :".head."insert\<CR>".spaces.placeholder."\<CR>.\<CR>"
+  else
+    let spaces = matchstr(getline(first),"^ *")
+    let placeholder = substitute(&commentstring, "%s", " ".target, "")
+
+    " Insert the placeholder where the text was extracted
+    silent exe "norm! :".first."insert\<CR>".spaces.placeholder."\<CR>.\<CR>"
   endif
 
   " Open a new window and paste the block in

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -59,11 +59,8 @@ function! s:Xtract(bang, target, ...) range abort
     if import != -1
       let import = substitute(import, '%s', a:target, 'g')
 
-      " Capture the indent present on the next-to-last line of the header
-      let header_indent = s:get_indent_at(headersize - 1)
-
-      " Append the import statement to the header
-      silent exe 'norm! :'.headersize."insert\<CR>".header_indent.import."\<CR>.\<CR>"
+      " Insert the import statement
+      call append(headersize - 1, s:get_indent_at(headersize - 1).import)
 
       " Advance the original line reference due to the paste
       let origline += 1
@@ -74,7 +71,7 @@ function! s:Xtract(bang, target, ...) range abort
   let placeholder = s:comment(&commentstring, target)
 
   " Insert a placeholder comment where the text was removed
-  silent exe 'norm! :'.origline."insert\<CR>\<C-u>".indent.placeholder."\<CR>.\<CR>"
+  call append(origline - 1, indent.placeholder)
 
   " Open target buffer and paste the extracted block at the end
   call s:open_buffer(target)

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -29,7 +29,7 @@ function! s:Xtract(bang, target, ...) range abort
   if target[:1] == '~/'
     let target = expand(target)
   elseif target[0] != '/'
-    let target = expand("%:h").'/'.target
+    let target = expand('%:h').'/'.target
   endif
 
   " Raise an error if target file exists and this was invoked without a bang
@@ -39,14 +39,14 @@ function! s:Xtract(bang, target, ...) range abort
 
   " Copy header (register 'x')
   if headersize
-    silent exe "1,".headersize."yank x"
+    silent exe '1,'.headersize.'yank x'
   endif
 
   " Capture the indent of the first selected line before the selected lines are removed
   let indent = s:get_indent_at(a:firstline)
 
   " Remove block (use default register)
-  silent exe a:firstline.",".a:lastline."del"
+  silent exe a:firstline.','.a:lastline.'del'
 
   " Keep track of the original line where the content was extracted from
   let origline = a:firstline
@@ -57,13 +57,13 @@ function! s:Xtract(bang, target, ...) range abort
     let import = s:get_importstring()
 
     if import != -1
-      let import = substitute(import, "%s", a:target, "g")
+      let import = substitute(import, '%s', a:target, 'g')
 
       " Capture the indent present on the next-to-last line of the header
       let header_indent = s:get_indent_at(headersize - 1)
 
       " Append the import statement to the header
-      silent exe "norm! :".headersize."insert\<CR>".header_indent.import."\<CR>.\<CR>"
+      silent exe 'norm! :'.headersize."insert\<CR>".header_indent.import."\<CR>.\<CR>"
 
       " Advance the original line reference due to the paste
       let origline += 1
@@ -73,8 +73,8 @@ function! s:Xtract(bang, target, ...) range abort
   " Build a placeholder comment that refers to the new file that was created
   let placeholder = s:comment(&commentstring, target)
 
-  " Insert the placeholder where the text was removed
-  silent exe "norm! :".origline."insert\<CR>\<C-u>".indent.placeholder."\<CR>.\<CR>"
+  " Insert a placeholder comment where the text was removed
+  silent exe 'norm! :'.origline."insert\<CR>\<C-u>".indent.placeholder."\<CR>.\<CR>"
 
   " Open target buffer and paste the extracted block at the end
   call s:open_buffer(target)
@@ -107,7 +107,7 @@ function! s:open_buffer(name)
     endif
   endif
 
-  silent exe "split ".a:name
+  silent exe 'split '.a:name
 endfunction
 
 function! s:paste_append()

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -25,8 +25,8 @@ function! s:Xtract(bang, target, ...) range abort
   let target = a:target
   let extension = expand("%:e")
 
-  " If current file has an extension, append it
-  if !empty(extension)
+  " If current file has an extension and the target doesn't already have it, append it
+  if !empty(extension) && !s:path_has_extension(target, extension)
     let target .= '.'.extension
   endif
 
@@ -87,6 +87,10 @@ function! s:Xtract(bang, target, ...) range abort
   " Remove extra lines at the end of the file
   silent! '%s#\($\n\s*\)\+\%$##'
   silent 1
+endfunction
+
+function! s:path_has_extension(path, ext)
+  return strcharpart(a:path, strchars(a:path) - (strchars(a:ext) + 1), strchars(a:ext) + 1) == ".".a:ext
 endfunction
 
 function! s:get_placeholder()

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -73,6 +73,10 @@ function! s:Xtract(bang, target, ...) range abort
   " Insert a placeholder comment where the text was removed
   call append(origline - 1, indent.placeholder)
 
+  " Place the cursor and center the view on the line with the placeholder comment
+  silent exe origline.'|'
+  silent exe 'norm! z.'
+
   " Open target buffer and paste the extracted block at the end
   call s:open_buffer(target)
   call s:paste_append()

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -73,9 +73,8 @@ function! s:Xtract(bang, target, ...) range abort
   " Insert a placeholder comment where the text was removed
   call append(origline - 1, indent.placeholder)
 
-  " Place the cursor and center the view on the line with the placeholder comment
+  " Place the cursor on the line with the placeholder comment
   silent exe origline.'|'
-  silent exe 'norm! z.'
 
   " Open target buffer and paste the extracted block at the end
   call s:open_buffer(target)
@@ -93,6 +92,11 @@ function! s:Xtract(bang, target, ...) range abort
 
   " Put the cursor at the top of the new buffer
   silent 1
+
+  " Briefly switch to the original window to center the view
+  call win_gotoid(win_getid(winnr('#')))
+  silent exe 'norm! z.'
+  call win_gotoid(win_getid(winnr('#')))
 
   " Output message
   let numlines = a:lastline - a:firstline + 1

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -94,9 +94,9 @@ function! s:Xtract(bang, target, ...) range abort
   silent 1
 
   " Briefly switch to the original window to center the view
-  call win_gotoid(win_getid(winnr('#')))
+  noautocmd wincmd p
   silent exe 'norm! z.'
-  call win_gotoid(win_getid(winnr('#')))
+  noautocmd wincmd p
 
   " Output message
   let numlines = a:lastline - a:firstline + 1

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -13,7 +13,7 @@ let g:xtract_importstrings = {
 
 " Extracts the current selection into a new file.
 "
-"     :<range>Xtract <newfile> <header: optional>
+"     :<range>Xtract <newfile> <headersize: optional>
 "
 " For example:
 "
@@ -22,7 +22,7 @@ let g:xtract_importstrings = {
 command -range -bang -nargs=* Xtract :<line1>,<line2>call s:Xtract(<bang>0,<f-args>)
 
 function! s:Xtract(bang, target, ...) range abort
-  let header = get(a:, '1')
+  let headersize = get(a:, '1')
   let target = a:target
   let extension = expand("%:e")
   let indent = s:get_indent_at(a:firstline)
@@ -45,8 +45,8 @@ function! s:Xtract(bang, target, ...) range abort
   endif
 
   " Copy header (register 'x')
-  if header
-    silent exe "1,".header."yank x"
+  if headersize
+    silent exe "1,".headersize."yank x"
   endif
 
   " Remove block (use default register)
@@ -55,19 +55,19 @@ function! s:Xtract(bang, target, ...) range abort
   " Keep track of the original line where the content was extracted from
   let origline = a:firstline
 
-  " Insert import statement right after the header (if header was specified
+  " Insert import statement at the end of the header (if headersize was specified
   " and we have an appropriate import template)
-  if header
+  if headersize
     let import = s:get_importstring()
 
     if import != -1
       let import = substitute(import, "%s", a:target, "g")
 
       " Capture the indent present on the next-to-last line of the header
-      let header_indent = s:get_indent_at(header - 1)
+      let header_indent = s:get_indent_at(headersize - 1)
 
       " Append the import statement to the header
-      silent exe "norm! :".header."insert\<CR>".header_indent.import."\<CR>.\<CR>"
+      silent exe "norm! :".headersize."insert\<CR>".header_indent.import."\<CR>.\<CR>"
 
       " Advance the original line reference due to the paste
       let origline += 1
@@ -84,8 +84,8 @@ function! s:Xtract(bang, target, ...) range abort
   call s:open_buffer(target)
   call s:paste_append()
 
-  " Insert the header (if specified) at the top
-  if header
+  " Insert the header (if headersize specified) at the top
+  if headersize
     silent put! x
   endif
 

--- a/plugin/xtract.vim
+++ b/plugin/xtract.vim
@@ -22,19 +22,24 @@ function! s:Xtract(bang, target, ...) range abort
   let last = a:lastline
   let head = get(a:, '1')
   let range = first.",".last
-  let ext = expand("%:e")
-  let fname = a:target
+  let target = a:target
+  let extension = expand("%:e")
 
-  if !empty(ext)
-    let fname .= '.'.ext
+  " If current file has an extension, append it
+  if !empty(extension)
+    let target .= '.'.extension
   endif
 
-  let path = expand("%:h")       " /path/to
-  let fullpath = path."/".fname  " /path/to/target.js
+  " Build the full target path
+  if target[0] == '~' && target[1] == '/'
+    let target = expand(target)
+  elseif target[0] != '/'
+    let target = expand("%:h").'/'.target
+  endif
 
   " Raise an error if invoked without a bang
-  if filereadable(fullpath) && !a:bang
-    return s:error('E13: File exists (add ! to override): '.fullpath)
+  if filereadable(target) && !a:bang
+    return s:error('E13: File exists (add ! to override): '.target)
   endif
 
   " Copy header (register 'x')
@@ -59,7 +64,7 @@ function! s:Xtract(bang, target, ...) range abort
   endif
 
   " Open a new window and paste the block in
-  silent execute "split ".fullpath
+  silent execute "split ".target
   silent put
   silent 1
   silent normal '"_dd'
@@ -70,8 +75,8 @@ function! s:Xtract(bang, target, ...) range abort
   endif
 
   " mkdir -p
-  if !isdirectory(fnamemodify(fullpath, ':h'))
-    call mkdir(fnamemodify(fullpath, ':h'), 'p')
+  if !isdirectory(fnamemodify(target, ':h'))
+    call mkdir(fnamemodify(target, ':h'), 'p')
   endif
 
   " Remove extra lines at the end of the file


### PR DESCRIPTION
@rstacruz, I've been quite enjoying using your vim-xtract plugin. I like how it assists in code refactoring by replacing the extracted text with an import statement in the correct programming language and implicitly assumes the same file extension as the original file.

However, my frequent use case is extracting file parts to a new file at a path starting with my home directory, so I quickly discovered that it creates a folder named `~` in the current working directory instead of treating tilde as the usual alias. Although I'm usually pretty confident whether to cut the blue wire or the red wire, I felt rather uneasy adding anything similar to `rm -rf \~` to my command history.

I hope you're fond of the improvements I've made, which include the ability to discern a relative path from an absolute path, more sophisticated behavior with respect to file extensions and reinstatement of generic placeholder inclusion, which seems to have disappeared with the introduction of header yanking support in dbd233350d347fb7ad17b66819ce30c0d7925ba2.